### PR TITLE
MINOR: Create flashcard button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ This changelog follows the semantic versioning standard(https://semver.org)
 - N/A
 -->
 
+## 3.1.0 - 2024-06-10
+
+### Added
+
+- New `CreateFlashcardSetDialogue` modal to handle creating a flashcard set
+- Added a basic edit-flashcard page  with most features and API calls unimplemented which the `CreateFlashcardSetDialogue` modal takes the user to when a flashcard is created. The page can be passed `newSet`, which if true, won't request flashcard data from the server. When implementing the edit-flashcard page fully, the page should use the API to read flashcard details when `newSet` is not true
+- Added basic `CreateFolderDialogue` modal, which does not work yet
+
+### Changed
+
+- Updated `CONTRIBUTING.md` to reflect the latest database changes
+
 ## 3.0.1 - 2024-06-07
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Welcome to this guide! Read more to learn how to contribute. For quick reference
 	* 1.2. [Running the React Frontend App](#RunningtheReactFrontendApp)
 * 2. [Contributing to the Backend API](#ContributingtotheBackendAPI)
 	* 2.1. [Quick Explanation](#QuickExplanation-1)
-	* 2.2. [Using a Local Files (Recommended)](#UsingaLocalFilesRecommended)
+	* 2.2. [Using a Local Setup (Recommended)](#UsingaLocalSetupRecommended)
 	* 2.3. [Using Firebase as the database](#UsingFirebaseasthedatabase)
 	* 2.4. [Serving the frontend](#Servingthefrontend)
 * 3. [Some Extra Information...](#SomeExtraInformation...)
@@ -65,7 +65,7 @@ To determine whether Firebase or local json files are used, `backend/database/da
 
 * If `type="production"`, the production Firebase server is used
 
-* If `type="local"`, local files are used
+* If `type="local"`, a local firebase server is used
 
 Depending on the value of the `type` variable, either the `FirebaseDatabase` or `LocalDatabase` classes are initialised, and the initialised instance is stored
 by the `Database` class as `db`. `FirebaseDatabase` and `LocalDatabase` inherit from the `DatabaseAbstract` abstract class, and so must have a `get`, `save` and
@@ -73,15 +73,19 @@ by the `Database` class as `db`. `FirebaseDatabase` and `LocalDatabase` inherit 
 
 Note that API documentation is in `docs/`
 
-###  2.2. <a name='UsingaLocalFilesRecommended'></a>Using a Local Files (Recommended)
+###  2.2. <a name='UsingaLocalSetupRecommended'></a>Using a Local Setup (Recommended)
 
-To contribute to the backend, using local files, follow these steps:
+To contribute to the backend, using local a local Firebase setup, follow these steps:
 
 * Clone the repository and `cd` into it
 
 * Run `pip install -r requirements.txt`
 
 * Make sure `backend/database/database_config.py` stores `type="local"`
+
+* Run `bash firebase_emulator.sh` - this runs a local firebase docker image for development
+  * `firebase_emulator.sh` is currently only avaliable for Linux, but since it only uses docker and a `curl` command, it should be fairly easy to port to Windows
+  * `docker` and `curl` are required to run the emulator
 
 * Run `python3 backend/main.py`
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """Package level information
 """
 
-__version__ = "3.0.1"
+__version__ = "3.1.0"

--- a/backend/database/database_config.py
+++ b/backend/database/database_config.py
@@ -1,2 +1,2 @@
-#type="production"
-type="local"
+type="production"
+#type="local"

--- a/backend/database/database_config.py
+++ b/backend/database/database_config.py
@@ -1,2 +1,2 @@
-type="production"
-#type="local"
+#type="production"
+type="local"

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,6 @@ app.register_blueprint(card_management_routes)
 app.register_blueprint(goal_routes)
 server_addr = ('0.0.0.0', 5000)
 
-
 # Serve the React frontend from the frontend/build folder
 @app.route('/', defaults={
     'path': ''})

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import SignInPage from './screens/SignIn';
 import MainPage from "./screens/MainPage";
 import Flashcards from './screens/Flashcards';
+import EditFlashcard from './screens/EditFlashcard';
 import { getCookie } from './api/Authentication';
 
 
@@ -15,6 +16,7 @@ function App() {
           <Route path="/" element={<SignInPage active={false}/>} />
           <Route path="/dashboard" element={<MainPage userID={userID} setUserID={setUserID}/>} />
           <Route path="/flashcards" element={<Flashcards />} />
+          <Route path="/edit-flashcard-set" element={<EditFlashcard />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/frontend/src/api/Api.js
+++ b/frontend/src/api/Api.js
@@ -188,6 +188,25 @@ class ApiManager {
             setReload(true);
         });
     }
+
+    createFlashcard(userID, flashcardName, flashcardDescription, folder, cards, loadEditFlashcardPage) {
+        /*
+        Create a flashcard
+        */
+        const url = 'create-flashcard';
+        const data = {
+            "userID": userID,
+            "flashcardName": flashcardName,
+            "flashcardDescription": flashcardDescription,
+            "folder": folder,
+            "cards": cards
+       }
+
+        this.fetchData(data, url, status => {
+            loadEditFlashcardPage(data);
+        });
+    
+    }
 }
 
 const apiManager = new ApiManager();

--- a/frontend/src/api/config.js
+++ b/frontend/src/api/config.js
@@ -1,3 +1,3 @@
-const serverURL = "http://dolphinflashcards.com/api/";
-//const serverURL = "http://192.168.178.27:5000/api/";
+//const serverURL = "http://dolphinflashcards.com/api/";
+const serverURL = "http://192.168.178.27:5000/api/";
 export default serverURL;

--- a/frontend/src/api/config.js
+++ b/frontend/src/api/config.js
@@ -1,3 +1,3 @@
-//const serverURL = "http://dolphinflashcards.com/api/";
-const serverURL = "http://192.168.178.27:5000/api/";
+const serverURL = "http://dolphinflashcards.com/api/";
+//const serverURL = "http://192.168.178.27:5000/api/";
 export default serverURL;

--- a/frontend/src/componments/SearchBar/SearchBar.js
+++ b/frontend/src/componments/SearchBar/SearchBar.js
@@ -1,15 +1,33 @@
 import React from 'react';
 import '../../containers/Modal/NewGoalPopup/NewGoalPopup.css';
 
-function SearchBar({ searchTerm, setSearchTerm, view }) {
+function SearchBar({
+    searchTerm,
+    setSearchTerm,
+    view,
+    marginRight,
+    borderRadius,
+    paddingBottom,
+    placeholder,
+    width
+}) {
     return (
         <input
             className={view == "mobile" ? "input-mobile" : "input"}
             value={searchTerm}
             onChange={e => setSearchTerm(e.target.value)}
             defaultValue="Search"
-            style={{marginBottom: "0px", float: "left", marginLeft: view === "mobile" ? "0px" : "16px"}}
+            style={{
+                marginBottom: "0px",
+                float: "left",
+                marginLeft: view === "mobile" ? "0px" : "16px",
+                marginRight: marginRight,
+                borderRadius: borderRadius,
+                paddingBottom: paddingBottom,
+                width: width
+            }}
             type='text'
+            placeholder={placeholder}
         />
     );
 }

--- a/frontend/src/componments/Text/ErrorText/ErrorText.css
+++ b/frontend/src/componments/Text/ErrorText/ErrorText.css
@@ -1,0 +1,12 @@
+.error-text {
+    color:#d45454;
+    font-family: Roboto;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    width: fit-content;
+    margin: 0px;
+}

--- a/frontend/src/componments/Text/ErrorText/ErrorText.js
+++ b/frontend/src/componments/Text/ErrorText/ErrorText.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import './ErrorText.css';
+
+function ErrorText({ text, style={}}) {
+
+    return (
+        <p className="error-text" style={style}>{text}</p>
+    );
+}
+
+export default ErrorText;

--- a/frontend/src/componments/Text/ErrorText/index.js
+++ b/frontend/src/componments/Text/ErrorText/index.js
@@ -1,0 +1,1 @@
+export { default } from './ErrorText';

--- a/frontend/src/componments/Text/Paragraph/Paragraph.css
+++ b/frontend/src/componments/Text/Paragraph/Paragraph.css
@@ -12,3 +12,15 @@
     flex: 1 0 0;
     align-self: stretch;
 }
+
+.grey-italics{
+    flex: 1 0 0;
+    align-self: stretch;
+    color: var(--Grey-Text-Colour, #747474);
+
+    font-family: Roboto;
+    font-size: 16px;
+    font-style: italic;
+    font-weight: 400;
+    line-height: 20px; /* 125% */
+}

--- a/frontend/src/componments/Text/Paragraph/Paragraph.js
+++ b/frontend/src/componments/Text/Paragraph/Paragraph.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import './Paragraph.css'
 
-function Paragraph({ text, style={}, onClick=null }) {
+function Paragraph({ text, style={}, type="paragraph", onClick=null }) {
     return (
-        <p className="paragraph" style={style} onClick={onClick}>
+        <p className={type} style={style} onClick={onClick}>
             {text}
         </p>
     );

--- a/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
+++ b/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
@@ -23,6 +23,7 @@ function FolderElement({ element, name, child, folderKey, path, selectedPath, se
             setSelectedPath(null);
             setSelected(false);
         } else{
+            console.log(path);
             setSelectedPath(path);
             setSelected(true);
         }

--- a/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
+++ b/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
@@ -13,7 +13,6 @@ import './FolderElement.css';
 function FolderElement({ element, name, child, folderKey, path, selectedPath, setSelectedPath }) {
     const [selected, setSelected] = React.useState(false);
     const [showChildren, setShowChildren] = useState(false);
-
     function toggleChildren() {
         setShowChildren(!showChildren);
     }
@@ -30,6 +29,9 @@ function FolderElement({ element, name, child, folderKey, path, selectedPath, se
     }
 
     useEffect(() => {
+        console.log("Selected path and path");
+        console.log(selectedPath);
+        console.log(path);
         if (selectedPath !== path) {
             setSelected(false);
         }

--- a/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
+++ b/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
@@ -20,6 +20,7 @@ function FolderElement({ element, name, child, folderKey, path, selectedPath, se
 
     function toggleClick() {
         if (selected) {
+            setSelectedPath(null);
             setSelected(false);
         } else{
             setSelectedPath(path);

--- a/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
+++ b/frontend/src/containers/FlashcardOverview/FolderElement/FolderElement.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Image from '../../../componments/Image';
-import Paragraph from '../../../componments/Paragraph';
+import Paragraph from '../../../componments/Text/Paragraph';
 
 import horizontalTriangle from '../../../static/horizontal-triangle.svg';
 import verticalTriangle from '../../../static/vertical-triangle.svg';
@@ -10,7 +10,7 @@ import verticalTriangleWhite from '../../../static/vertical-triangle-white.svg';
 import '../FlashcardFolder.css';
 import './FolderElement.css';
 
-function FlashcardFolder({ element, name, child, folderKey, path, selectedPath, setSelectedPath }) {
+function FolderElement({ element, name, child, folderKey, path, selectedPath, setSelectedPath }) {
     const [selected, setSelected] = React.useState(false);
     const [showChildren, setShowChildren] = useState(false);
 
@@ -19,13 +19,10 @@ function FlashcardFolder({ element, name, child, folderKey, path, selectedPath, 
     }
 
     function toggleClick() {
-        console.log("Clicked");
         if (selected) {
             setSelected(false);
         } else{
-            console.log("Setting selectedPath to", path);
             setSelectedPath(path);
-            console.log("Set selectedPath to", selectedPath);
             setSelected(true);
         }
     }
@@ -62,4 +59,4 @@ function FlashcardFolder({ element, name, child, folderKey, path, selectedPath, 
     );
 }
 
-export default FlashcardFolder;
+export default FolderElement;

--- a/frontend/src/containers/FolderTreeView/FolderTreeView.js
+++ b/frontend/src/containers/FolderTreeView/FolderTreeView.js
@@ -5,7 +5,12 @@ import '../Modal/MoveFolderDialogue/MoveFolderDialogue.css';
 import '../Modal/Modal.css';
 
 function FolderTreeView({ visible, selectedPath, setSelectedPath }) {
-    const flashcardData = visible.flashcardData;
+    // If visible is not an array, add a "Your account" folder
+    if (visible[0] !== "User has no flashcards") {
+        visible = {"Your Account": visible}
+    };
+    console.log("Visible is");
+    console.log(visible);
 
     const renderElement = (element, folderName, path="") => {
         if (path !== "") {
@@ -17,7 +22,7 @@ function FolderTreeView({ visible, selectedPath, setSelectedPath }) {
         if (element.cards) {
         } else {
           return (
-            <FlashcardFolder
+            /*<FlashcardFolder
               element={element}
               name={folderName}
               path={path}
@@ -25,23 +30,32 @@ function FolderTreeView({ visible, selectedPath, setSelectedPath }) {
               selectedPath={selectedPath}
               setSelectedPath={setSelectedPath}
               child={Object.entries(element).map(([key, value]) => renderElement(value, key, path))}
+            />*/
+            <FolderElement
+                element={element}
+                name={folderName}
+                path={folderName}
+                folderKey={folderName + element.flashcardID}
+                selectedPath={selectedPath}
+                setSelectedPath={setSelectedPath}
+                child={Object.entries(element).map(([key, value]) => renderElement(value, key, path))}
             />
           );
         }
     };
 
     if (visible[0] !== "User has no flashcards") {
-        return Object.entries(flashcardData).map(([key, value]) => renderElement(value, key))
+        return Object.entries(visible).map(([key, value]) => renderElement(value, key))
     } else {
         return (
             <FolderElement
-            element={<div></div>}
-            name={"Your Account"}
-            path={""}
-            folderKey={""}
-            selectedPath={selectedPath}
-            setSelectedPath={setSelectedPath}
-            child={null}
+                element={<div></div>}
+                name={"Your Account"}
+                path={""}
+                folderKey={""}
+                selectedPath={selectedPath}
+                setSelectedPath={setSelectedPath}
+                child={null}
             />
         );
     }

--- a/frontend/src/containers/FolderTreeView/FolderTreeView.js
+++ b/frontend/src/containers/FolderTreeView/FolderTreeView.js
@@ -21,6 +21,16 @@ function FolderTreeView({ visible, selectedPath, setSelectedPath }) {
 
         if (element.cards) {
         } else {
+        // Make sure the path stays as "" for the first item, which is the root folder
+        // But shown to the user as a folder called "Your Account"
+        var pathName;
+        if (folderName === "Your Account") {
+            path = ""
+            pathName = ""
+        } else {
+            pathName = folderName;
+        }
+
           return (
             /*<FlashcardFolder
               element={element}
@@ -34,7 +44,7 @@ function FolderTreeView({ visible, selectedPath, setSelectedPath }) {
             <FolderElement
                 element={element}
                 name={folderName}
-                path={folderName}
+                path={pathName}
                 folderKey={folderName + element.flashcardID}
                 selectedPath={selectedPath}
                 setSelectedPath={setSelectedPath}

--- a/frontend/src/containers/FolderTreeView/FolderTreeView.js
+++ b/frontend/src/containers/FolderTreeView/FolderTreeView.js
@@ -4,8 +4,7 @@ import FolderElement from '../FlashcardOverview/FolderElement/FolderElement';
 import '../Modal/MoveFolderDialogue/MoveFolderDialogue.css';
 import '../Modal/Modal.css';
 
-function FolderTreeView({ visible }) {
-    const [selectedPath, setSelectedPath] = React.useState(null);
+function FolderTreeView({ visible, selectedPath, setSelectedPath }) {
     const flashcardData = visible.flashcardData;
 
     const renderElement = (element, folderName, path="") => {

--- a/frontend/src/containers/FolderTreeView/FolderTreeView.js
+++ b/frontend/src/containers/FolderTreeView/FolderTreeView.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import FlashcardFolder from '../FlashcardOverview/FlashcardFolder/FlashcardFolder';
+import FolderElement from '../FlashcardOverview/FolderElement/FolderElement';
+import '../Modal/MoveFolderDialogue/MoveFolderDialogue.css';
+import '../Modal/Modal.css';
+
+function FolderTreeView({ visible }) {
+    const [selectedPath, setSelectedPath] = React.useState(null);
+    const flashcardData = visible.flashcardData;
+
+    const renderElement = (element, folderName, path="") => {
+        if (path !== "") {
+            path = path + "/" + folderName;
+        } else {
+            path = folderName;
+        }
+
+        if (element.cards) {
+        } else {
+          return (
+            <FlashcardFolder
+              element={element}
+              name={folderName}
+              path={path}
+              folderKey={folderName + element.flashcardID}
+              selectedPath={selectedPath}
+              setSelectedPath={setSelectedPath}
+              child={Object.entries(element).map(([key, value]) => renderElement(value, key, path))}
+            />
+          );
+        }
+    };
+
+    if (visible[0] !== "User has no flashcards") {
+        return Object.entries(flashcardData).map(([key, value]) => renderElement(value, key))
+    } else {
+        return (
+            <FolderElement
+            element={<div></div>}
+            name={"Your Account"}
+            path={""}
+            folderKey={""}
+            selectedPath={selectedPath}
+            setSelectedPath={setSelectedPath}
+            child={null}
+            />
+        );
+    }
+}
+
+export default FolderTreeView;

--- a/frontend/src/containers/FolderTreeView/index.js
+++ b/frontend/src/containers/FolderTreeView/index.js
@@ -1,0 +1,1 @@
+export {default} from './FolderTreeView';

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -70,8 +70,8 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
 
     useEffect(() => {
       if (loadEditFlashcardPage) {
-        alert ("Loading page");
         setLoadingIconVisible(false);
+        //window.open("/edit-flashcard-set?newSet=true", "_self")
       }
     }, [loadEditFlashcardPage]);
 

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -20,6 +20,7 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     const [errorMessage, setErrorMessage] = useState(null);
     const [errorMessageVisibility, setErrorMessageVisibility] = useState("none");
     const [loadingIconVisible, setLoadingIconVisible] = useState("visisnle"); // If null, loading icon shows
+    const [loadEditFlashcardPage, setLoadEditFlashcardPage] = useState(false);
     const buttonStyle = {
         display: "inline-grid",
         margin: "0px 16px"
@@ -53,13 +54,27 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     function createSet() {
       setErrorMessageVisibility("block");
       if (errorMessage === null) {
-        /*if (selectedPath != null) {
+        if (selectedPath != null) {
           setLoadingIconVisible(null);
-          apiManager.createFlashcard(userID, flashcardName, flashcardDescription, folder, cards, loadEditFlashcardPage)
-        }*/
-        alert ("Clicked!");
+          apiManager.createFlashcard(
+            getCookie("userID"),
+            flashcardName,
+            flashcardDescription,
+            selectedPath,
+            [],
+            setLoadEditFlashcardPage
+          )
+        }
       }
     }
+
+    useEffect(() => {
+      if (loadEditFlashcardPage) {
+        alert ("Loading page");
+        setLoadingIconVisible(false);
+      }
+    }, [loadEditFlashcardPage]);
+
     useEffect(() => {
       setLoadingIconVisible("visible");
     }, [visible]);

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -6,12 +6,12 @@ import Heading3 from '../../../componments/Text/Heading3/Heading3';
 import FolderTreeView from '../../FolderTreeView';
 import apiManager from '../../../api/Api';
 import {getCookie} from '../../../api/Authentication';
-import './MoveFolderDialogue.css'
+import '../MoveFolderDialogue/MoveFolderDialogue.css'
 import '../Modal.css';
 import DelayedElement from '../../DelayedElement';
 import { dropIn } from '../../../animations/animations';
 
-function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
+function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     const [selectedPath, setSelectedPath] = React.useState(null);
     const [loadingIconVisible, setLoadingIconVisible] = useState("visisnle"); // If null, loading icon shows
     const buttonStyle = {
@@ -21,8 +21,8 @@ function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
     const flashcardID = visible.flashcardID;
     const currentPath = visible.path;
 
-    function moveFlashcard() {
-      if (selectedPath != null) {
+    function createSet() {
+      /*if (selectedPath != null) {
         setLoadingIconVisible(null);
         apiManager.moveFlashcard(
           getCookie("userID"),
@@ -32,7 +32,8 @@ function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
           setVisible,
           setReload
         )
-      }
+      }*/
+     alert ("Clicked!");
     }
     useEffect(() => {
       setLoadingIconVisible("visible");
@@ -47,7 +48,7 @@ function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
               animate="visible"
               exit="exit"
               variants={dropIn}
-              style={view == "desktop" ? {height: "fit-content"} : null}
+              style={view !== "mobile" ? {height: "fit-content"} : null}
             >
                 <Heading3 text="Choose a folder:" />
 
@@ -57,7 +58,7 @@ function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
 
                 <div className='button-container'>
                     <GhostButton text="Cancel" onClick={() => setVisible(false)} style={buttonStyle} />
-                    <Button text="Move" onClick={moveFlashcard} style={buttonStyle} />
+                    <Button text="Create" onClick={createSet} style={buttonStyle} />
                 </div>
                 <div className={"loading-icon-wrapper"}>
                   <DelayedElement child={<></>} childValue={loadingIconVisible} />
@@ -68,4 +69,4 @@ function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
     );
 }
 
-export default MoveFolderDialogue;
+export default CreateFlashcardSetDialogue;

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -71,7 +71,12 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     useEffect(() => {
       if (loadEditFlashcardPage) {
         setLoadingIconVisible(false);
-        //window.open("/edit-flashcard-set?newSet=true", "_self")
+        window.open(
+          "/edit-flashcard-set?newSet=true&flashcardName="
+          + flashcardName + "&folder=" + selectedPath
+          + "&flashcardDescription=" + flashcardDescription,
+          "_self"
+        );
       }
     }, [loadEditFlashcardPage]);
 

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -4,6 +4,7 @@ import GhostButton from '../../../componments/GhostButton';
 import Button from '../../../componments/Button';
 import Heading3 from '../../../componments/Text/Heading3/Heading3';
 import FolderTreeView from '../../FolderTreeView';
+import Paragraph from '../../../componments/Text/Paragraph';
 import apiManager from '../../../api/Api';
 import {getCookie} from '../../../api/Authentication';
 import '../MoveFolderDialogue/MoveFolderDialogue.css'
@@ -13,6 +14,8 @@ import { dropIn } from '../../../animations/animations';
 
 function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     const [selectedPath, setSelectedPath] = React.useState(null);
+    const [flashcardName, setFlashcardName] = useState("");
+    const [flashcardDescription, setFlashcardDescription] = useState("");
     const [loadingIconVisible, setLoadingIconVisible] = useState("visisnle"); // If null, loading icon shows
     const buttonStyle = {
         display: "inline-grid",
@@ -21,17 +24,20 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     const flashcardID = visible.flashcardID;
     const currentPath = visible.path;
 
+    // When the flashcard name is chaned using the input box
+    const onFlashcardNameChange = (event) => {
+      setFlashcardName(event.target.value);
+    };
+
+    // When the flashcard description is chaned using the input box
+    const onFlashcardDescriptionChange = (event) => {
+      setFlashcardDescription(event.target.value);
+    };
+
     function createSet() {
       /*if (selectedPath != null) {
         setLoadingIconVisible(null);
-        apiManager.moveFlashcard(
-          getCookie("userID"),
-          currentPath,
-          flashcardID,
-          selectedPath,
-          setVisible,
-          setReload
-        )
+        apiManager.createFlashcard(userID, flashcardName, flashcardDescription, folder, cards, loadEditFlashcardPage)
       }*/
      alert ("Clicked!");
     }
@@ -52,14 +58,27 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
             >
                 <Heading3 text="Choose a folder:" />
 
-                <div className="card-overview">
+                <div className="card-overview" style={{cursor: "pointer"}}>
                   <FolderTreeView visible={visible} />
+                </div>
+
+                <Heading3 text="Choose other details:" />
+
+                <div className="input-container">
+                    <Paragraph text="Name: " style={{ display: "flex", alignItems: "center" }} />
+                    <input type="text" className="input" value={flashcardName} onChange={onFlashcardNameChange}/>
+                </div>
+
+                <div className="input-container">
+                    <Paragraph text="Description: " style={{ display: "flex", alignItems: "center" }} />
+                    <input type="text" className="input" value={flashcardDescription} onChange={onFlashcardDescriptionChange}/>
                 </div>
 
                 <div className='button-container'>
                     <GhostButton text="Cancel" onClick={() => setVisible(false)} style={buttonStyle} />
                     <Button text="Create" onClick={createSet} style={buttonStyle} />
                 </div>
+
                 <div className={"loading-icon-wrapper"}>
                   <DelayedElement child={<></>} childValue={loadingIconVisible} />
                 </div>

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -5,6 +5,7 @@ import Button from '../../../componments/Button';
 import Heading3 from '../../../componments/Text/Heading3/Heading3';
 import FolderTreeView from '../../FolderTreeView';
 import Paragraph from '../../../componments/Text/Paragraph';
+import ErrorText from '../../../componments/Text/ErrorText';
 import apiManager from '../../../api/Api';
 import {getCookie} from '../../../api/Authentication';
 import '../MoveFolderDialogue/MoveFolderDialogue.css'
@@ -16,6 +17,8 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
     const [selectedPath, setSelectedPath] = React.useState(null);
     const [flashcardName, setFlashcardName] = useState("");
     const [flashcardDescription, setFlashcardDescription] = useState("");
+    const [errorMessage, setErrorMessage] = useState(null);
+    const [errorMessageVisibility, setErrorMessageVisibility] = useState("none");
     const [loadingIconVisible, setLoadingIconVisible] = useState("visisnle"); // If null, loading icon shows
     const buttonStyle = {
         display: "inline-grid",
@@ -34,12 +37,28 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
       setFlashcardDescription(event.target.value);
     };
 
+    useEffect(() => {
+      /* Generate an error message when the user clicks "Submit" */
+      if (selectedPath === null) {
+        setErrorMessage("Please select a folder!");
+      } else if (flashcardName === "") {
+        setErrorMessage("Please enter a name!");
+      } else if (flashcardDescription === "") {
+        setErrorMessage("Please enter a description!");
+      } else {
+        setErrorMessage(null);
+      }
+    }, [selectedPath, flashcardName, flashcardDescription]);
+
     function createSet() {
-      /*if (selectedPath != null) {
-        setLoadingIconVisible(null);
-        apiManager.createFlashcard(userID, flashcardName, flashcardDescription, folder, cards, loadEditFlashcardPage)
-      }*/
-     alert ("Clicked!");
+      setErrorMessageVisibility("block");
+      if (errorMessage === null) {
+        /*if (selectedPath != null) {
+          setLoadingIconVisible(null);
+          apiManager.createFlashcard(userID, flashcardName, flashcardDescription, folder, cards, loadEditFlashcardPage)
+        }*/
+        alert ("Clicked!");
+      }
     }
     useEffect(() => {
       setLoadingIconVisible("visible");
@@ -59,7 +78,7 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
                 <Heading3 text="Choose a folder:" />
 
                 <div className="card-overview" style={{cursor: "pointer"}}>
-                  <FolderTreeView visible={visible} />
+                  <FolderTreeView visible={visible} selectedPath={selectedPath} setSelectedPath={setSelectedPath}/>
                 </div>
 
                 <Heading3 text="Choose other details:" />
@@ -74,8 +93,10 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
                     <input type="text" className="input" value={flashcardDescription} onChange={onFlashcardDescriptionChange}/>
                 </div>
 
+                <ErrorText text={errorMessage} style={{ display: errorMessageVisibility}} />
+
                 <div className='button-container'>
-                    <GhostButton text="Cancel" onClick={() => setVisible(false)} style={buttonStyle} />
+                    <GhostButton text="Cancel" onClick={() => {setErrorMessageVisibility("none"); setVisible(false)}} style={buttonStyle} />
                     <Button text="Create" onClick={createSet} style={buttonStyle} />
                 </div>
 

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/index.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/index.js
@@ -1,0 +1,1 @@
+export {default} from './CreateFlashcardSetDialogue';

--- a/frontend/src/containers/Modal/CreateFolderDialogue/CreateFolderDialogue.js
+++ b/frontend/src/containers/Modal/CreateFolderDialogue/CreateFolderDialogue.js
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import {motion} from 'framer-motion';
+import GhostButton from '../../../componments/GhostButton';
+import Button from '../../../componments/Button';
+import Heading3 from '../../../componments/Text/Heading3/Heading3';
+import FolderTreeView from '../../FolderTreeView';
+import Paragraph from '../../../componments/Text/Paragraph';
+import ErrorText from '../../../componments/Text/ErrorText';
+import apiManager from '../../../api/Api';
+import {getCookie} from '../../../api/Authentication';
+import '../MoveFolderDialogue/MoveFolderDialogue.css'
+import '../Modal.css';
+import DelayedElement from '../../DelayedElement';
+import { dropIn } from '../../../animations/animations';
+
+function CreateFolderDialogue({ visible, setVisible, view, setReload }) {
+    const [selectedPath, setSelectedPath] = React.useState(null);
+    const [folderName, setFolderName] = useState("");
+    const [errorMessage, setErrorMessage] = useState(null);
+    const [errorMessageVisibility, setErrorMessageVisibility] = useState("none");
+    const [loadingIconVisible, setLoadingIconVisible] = useState("visisnle"); // If null, loading icon shows
+    const [loadEditFlashcardPage, setLoadEditFlashcardPage] = useState(false);
+    const buttonStyle = {
+        display: "inline-grid",
+        margin: "0px 16px"
+    }
+    const flashcardID = visible.flashcardID;
+    const currentPath = visible.path;
+
+    // When the flashcard name is chaned using the input box
+    const onFlashcardNameChange = (event) => {
+      setFolderName(event.target.value);
+    };
+
+
+    useEffect(() => {
+      /* Generate an error message when the user clicks "Submit" */
+      if (selectedPath === null) {
+        setErrorMessage("Please select a folder!");
+      } else if (folderName === "") {
+        setErrorMessage("Please enter a name!");
+      } else {
+        setErrorMessage(null);
+      }
+    }, [selectedPath, folderName]);
+
+    function createSet() {
+      setErrorMessageVisibility("block");
+      if (errorMessage === null) {
+        if (selectedPath != null) {
+          setLoadingIconVisible(null);
+          /*apiManager.createFlashcard(
+            getCookie("userID"),
+            folderName,
+            flashcardDescription,
+            selectedPath,
+            [],
+            setLoadEditFlashcardPage
+          )*/
+        }
+      }
+    }
+
+    useEffect(() => {
+      setLoadingIconVisible("visible");
+    }, [visible]);
+
+      return (
+        visible !== false ?
+        <div className={view != "mobile" ? 'darken-background' : 'whiten-background'}>
+            <motion.div
+              className={view == "desktop" ? "popup-container" : view == "tablet" ? "popup-container-tablet" : "popup-container-mobile"}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              variants={dropIn}
+              style={view !== "mobile" ? {height: "fit-content"} : null}
+            >
+                <Heading3 text="Choose a location:" />
+
+                <div className="card-overview" style={{cursor: "pointer"}}>
+                  <FolderTreeView visible={visible} selectedPath={selectedPath} setSelectedPath={setSelectedPath}/>
+                </div>
+
+                <Heading3 text="Choose other details:" />
+
+                <div className="input-container">
+                    <Paragraph text="Name: " style={{ display: "flex", alignItems: "center" }} />
+                    <input type="text" className="input" value={folderName} onChange={onFlashcardNameChange}/>
+                </div>
+
+                <ErrorText text={errorMessage} style={{ display: errorMessageVisibility}} />
+
+                <div className='button-container'>
+                    <GhostButton text="Cancel" onClick={() => {setErrorMessageVisibility("none"); setVisible(false)}} style={buttonStyle} />
+                    <Button text="Create" onClick={createSet} style={buttonStyle} />
+                </div>
+
+                <div className={"loading-icon-wrapper"}>
+                  <DelayedElement child={<></>} childValue={loadingIconVisible} />
+                </div>
+            </motion.div>
+        </div>
+        : null
+    );
+}
+
+export default CreateFolderDialogue;

--- a/frontend/src/containers/Modal/CreateFolderDialogue/index.js
+++ b/frontend/src/containers/Modal/CreateFolderDialogue/index.js
@@ -1,0 +1,1 @@
+export {default} from './CreateFolderDialogue';

--- a/frontend/src/containers/Modal/MoveFolderDialogue/MoveFolderDialogue.js
+++ b/frontend/src/containers/Modal/MoveFolderDialogue/MoveFolderDialogue.js
@@ -52,7 +52,7 @@ function MoveFolderDialogue({ visible, setVisible, view, setReload }) {
                 <Heading3 text="Choose a folder:" />
 
                 <div className="card-overview">
-                  <FolderTreeView visible={visible} />
+                  <FolderTreeView visible={visible} selectedPath={selectedPath} setSelectedPath={setSelectedPath}/>
                 </div>
 
                 <div className='button-container'>

--- a/frontend/src/screens/EditFlashcard.css
+++ b/frontend/src/screens/EditFlashcard.css
@@ -1,0 +1,26 @@
+.flashcard-set-header {
+    display: flex;
+    align-items: center; /* Align items vertically centered */
+    width: fit-content;
+}
+
+.flashcard-set-header .link {
+    margin-right: 10px; /* Add some space between the elements */
+}
+
+.search-bar {
+    display: flex;
+    align-items: flex-start; /* Align items vertically centered */
+    width: 100%;
+}
+
+.page-container{
+    width: 80%;
+}
+
+.sort-dialogue{
+    display: flex;
+    align-items: center; /* Align items vertically centered */
+    width: fit-content;
+    margin-left: 16px;
+}

--- a/frontend/src/screens/EditFlashcard.js
+++ b/frontend/src/screens/EditFlashcard.js
@@ -11,12 +11,17 @@ import HamburgerBar from '../containers/HamburgerBar/HamburgerBar';
 import MoveFolderDialogue from '../containers/Modal/MoveFolderDialogue/MoveFolderDialogue';
 import CreateFlashcardSetDialogue from '../containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue';
 import Paragraph from '../componments/Text/Paragraph';
+import Heading4 from '../componments/Text/Heading4';
+import SearchBar from '../componments/SearchBar/SearchBar';
+import Button from '../componments/Button/Button';
 import apiManager from '../api/Api';
 import '../componments/Text/Text/Text.css';
 import '../componments/Text/Link/Link.css';
 import '../componments/Text/BoldParagraph/Bold.css';
 import './EditFlashcard.css';
+import '../containers/Modal/NewGoalPopup/NewGoalPopup.css';
 import { getCookie } from '../api/Authentication';
+import Heading5 from '../componments/Text/Heading5/Heading5';
 
 function Flashcards() {
   // Set general variables
@@ -25,6 +30,7 @@ function Flashcards() {
   const [moveFolderDialogueVisible, setMoveFolderDialogueVisible] = useState(false);
   const [reload, setReload] = useState(true);
   const [createCardDialogueVisible, setCreateCardDialogueVisible] = useState(false);
+  const [sortType, setSortType] = useState("most-recent");
   const [flashcardData, setFlashcardData] = useState(null);
 
   // Use useLocation hook to get the current location object
@@ -49,6 +55,10 @@ function Flashcards() {
   const [flashcardBoxHorizontalPadding, setFlashcardBoxHorizontalPadding] = useState(
     view == "mobile" ? "8px" : "16px"
   );
+
+  function handleOptionChange(event) {
+    setSortType(event.target.value);
+  }  
 
   // Manage resizing the window size when needed
   useEffect(() => {
@@ -121,20 +131,63 @@ function Flashcards() {
           <WhiteOverlay
             style={{
                 height: "max-content",
+                padding: "16px",
                 paddingBottom: view == "mobile" ? "80px" : "",
                 width: view == "desktop" ? "100%" : "calc(100% - 16px)"
               }}
             >
-            <div style={{maxWidth: "1200px", margin: "auto"}}>
-              <div className='flashcard-set-header'>
-                <p className='link'>
-                  &lt; Back to {newSet === "true" ? "flashcards" : "studying"}
-                </p>
-                <Paragraph text={
-                  folder == "" ? "'Your Account > " + flashcardName  + "'": folder + " > " + flashcardName + "'"
-                } type="grey-italics" />
+            <div className='flashcard-set-header'>
+              <p
+                className='link'
+                style={{paddingLeft: "16px"}}
+                onClick={() => {window.open("/flashcards", "_self")}}
+              >
+                &lt; Back to {newSet === "true" ? "flashcards" : "studying"}
+              </p>
+              <Paragraph text={
+                folder == "" ? '"Your Account > ' + flashcardName  + '"': folder.replace(/\//g, ' > ') + ' > ' + flashcardName + '"'
+              } type="grey-italics" />
               </div>
-            </div>
+              <div className="search-bar">
+                <SearchBar
+                  searchTerm={""}
+                  setSearchTerm={console.log}
+                  view={view}
+                  marginRight="0px"
+                  borderRadius="8px 0 0 8px"
+                  paddingBottom="8px"
+                  placeholder="Search..."
+                  width="100%"
+                />
+                <Button
+                  text="Search"
+                  onClick={() => {alert("Searching")}}
+                  style={{
+                    marginTop: "8px",
+                    marginBottom: "8px",
+                    borderRadius: "0 8px 8px 0",
+                    marginRight: "8px"
+                  }}
+                />
+              </div>
+              <div className='sort-dialogue'>
+                <Paragraph text="Sort:" />
+                <select className="dropdown" value={sortType} onChange={handleOptionChange}>
+                    <option value="a-z" className="option">A-Z</option>
+                    <option value="z-a" className="option">Z-A</option>
+                    <option value="most-recent" className="option">Most Recent</option>
+                    <option value="least-recent" className="option">Least Recent</option>
+                </select>
+              </div>
+              <Button text="+ New Card" onClick={() => {alert ("Creating new card")}} />
+              {
+                flashcardData != null && flashcardData.cards.length === 0
+                ? <Heading5
+                    text="You don't have any flashcards yet!"
+                    style={{margin: "8px"}}
+                  />
+                : <></>
+              }
           </WhiteOverlay>
 
         </GridItem>

--- a/frontend/src/screens/EditFlashcard.js
+++ b/frontend/src/screens/EditFlashcard.js
@@ -1,4 +1,5 @@
 import {React, useState, useEffect} from 'react';
+import { useLocation } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import '../App.css';
 import BlobBackground from '../containers/BlobBackground';
@@ -22,6 +23,22 @@ function Flashcards() {
   const [moveFolderDialogueVisible, setMoveFolderDialogueVisible] = useState(false);
   const [reload, setReload] = useState(true);
   const [createCardDialogueVisible, setCreateCardDialogueVisible] = useState(false);
+  const [flashcardData, setFlashcardData] = useState(null);
+
+  // Use useLocation hook to get the current location object
+  const location = useLocation();
+  // Create a new URLSearchParams object with the search part of the location
+  const queryParams = new URLSearchParams(location.search);
+
+  // Get the query parameters from the URL
+  const newSet = queryParams.get('newSet');
+  const flashcardName = queryParams.get('flashcardName');
+  const folder = queryParams.get('folder');
+  const description = queryParams.get('flashcardDescription');
+
+  console.log("newSet: " + newSet);
+  console.log("flashcardName: " + flashcardName);
+  console.log("folder: " + folder);
 
   // Set variables for the size
   const mobileBreakpoint = 650;
@@ -46,6 +63,19 @@ function Flashcards() {
   
     // Set up the event listener for resize
     window.addEventListener("resize", handleResize);
+
+    // Request the flashcard set details if it is not a new set
+    if (newSet === "true") {
+      setFlashcardData(
+        {
+          "cards": [],
+          "description": description,
+          "name": flashcardName
+        },
+      )
+    } else {
+      alert ("Getting set details");
+    }
 
     // Clean up the event listener when the component is unmounted
     return () => {

--- a/frontend/src/screens/EditFlashcard.js
+++ b/frontend/src/screens/EditFlashcard.js
@@ -15,7 +15,7 @@ import '../componments/Text/Link/Link.css';
 import '../componments/Text/BoldParagraph/Bold.css';
 import { getCookie } from '../api/Authentication';
 
-function Flashcards({ flashcardData }) {
+function Flashcards() {
   // Set general variables
   const title = "Flashcards";
   const [mobileSidePanelVisible, setMobileSidePanelVisible] = useState(false);

--- a/frontend/src/screens/EditFlashcard.js
+++ b/frontend/src/screens/EditFlashcard.js
@@ -10,10 +10,12 @@ import WhiteOverlay from '../componments/WhiteOverlay/WhiteOverlay';
 import HamburgerBar from '../containers/HamburgerBar/HamburgerBar';
 import MoveFolderDialogue from '../containers/Modal/MoveFolderDialogue/MoveFolderDialogue';
 import CreateFlashcardSetDialogue from '../containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue';
+import Paragraph from '../componments/Text/Paragraph';
 import apiManager from '../api/Api';
 import '../componments/Text/Text/Text.css';
 import '../componments/Text/Link/Link.css';
 import '../componments/Text/BoldParagraph/Bold.css';
+import './EditFlashcard.css';
 import { getCookie } from '../api/Authentication';
 
 function Flashcards() {
@@ -35,10 +37,6 @@ function Flashcards() {
   const flashcardName = queryParams.get('flashcardName');
   const folder = queryParams.get('folder');
   const description = queryParams.get('flashcardDescription');
-
-  console.log("newSet: " + newSet);
-  console.log("flashcardName: " + flashcardName);
-  console.log("folder: " + folder);
 
   // Set variables for the size
   const mobileBreakpoint = 650;
@@ -128,7 +126,14 @@ function Flashcards() {
               }}
             >
             <div style={{maxWidth: "1200px", margin: "auto"}}>
-              <p>Create a Flashcard</p>
+              <div className='flashcard-set-header'>
+                <p className='link'>
+                  &lt; Back to {newSet === "true" ? "flashcards" : "studying"}
+                </p>
+                <Paragraph text={
+                  folder == "" ? "'Your Account > " + flashcardName  + "'": folder + " > " + flashcardName + "'"
+                } type="grey-italics" />
+              </div>
             </div>
           </WhiteOverlay>
 

--- a/frontend/src/screens/EditFlashcard.js
+++ b/frontend/src/screens/EditFlashcard.js
@@ -1,0 +1,112 @@
+import {React, useState, useEffect} from 'react';
+import { Helmet } from 'react-helmet';
+import '../App.css';
+import BlobBackground from '../containers/BlobBackground';
+import GridContainer from '../componments/GridContainer/GridContainer';
+import GridItem from '../componments/GridItem/GridItem';
+import SidePanel from '../containers/SidePanel/SidePanel';
+import WhiteOverlay from '../componments/WhiteOverlay/WhiteOverlay';
+import HamburgerBar from '../containers/HamburgerBar/HamburgerBar';
+import MoveFolderDialogue from '../containers/Modal/MoveFolderDialogue/MoveFolderDialogue';
+import CreateFlashcardSetDialogue from '../containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue';
+import apiManager from '../api/Api';
+import '../componments/Text/Text/Text.css';
+import '../componments/Text/Link/Link.css';
+import '../componments/Text/BoldParagraph/Bold.css';
+import { getCookie } from '../api/Authentication';
+
+function Flashcards({ flashcardData }) {
+  // Set general variables
+  const title = "Flashcards";
+  const [mobileSidePanelVisible, setMobileSidePanelVisible] = useState(false);
+  const [moveFolderDialogueVisible, setMoveFolderDialogueVisible] = useState(false);
+  const [reload, setReload] = useState(true);
+  const [createCardDialogueVisible, setCreateCardDialogueVisible] = useState(false);
+
+  // Set variables for the size
+  const mobileBreakpoint = 650;
+  const tabletBreakpoint = 1090;
+  const [width, setWidth] = useState(window.innerWidth);
+  const [view, setView] = useState(
+    width < mobileBreakpoint ? "mobile"
+    : width < tabletBreakpoint ? "tablet" : "desktop"
+  );
+  const [flashcardBoxHorizontalPadding, setFlashcardBoxHorizontalPadding] = useState(
+    view == "mobile" ? "8px" : "16px"
+  );
+
+  // Manage resizing the window size when needed
+  useEffect(() => {
+    function handleResize() {
+      setWidth(window.innerWidth);
+    }
+  
+    // Set the initial window size
+    setWidth(window.innerWidth);
+  
+    // Set up the event listener for resize
+    window.addEventListener("resize", handleResize);
+
+    // Clean up the event listener when the component is unmounted
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    setView(
+      width < mobileBreakpoint ? "mobile"
+      : width < tabletBreakpoint ? "tablet" : "desktop");
+    setFlashcardBoxHorizontalPadding(
+      view == "mobile" ? "8px" : "16px"
+    );
+  }, [width]);
+
+  return (
+    <div style={{top: "0px"}}>
+      <Helmet>
+        <title>{ title }</title>
+        <meta
+            name="viewport" 
+            content="width=device-width, initial-scale=1.0">
+        </meta>
+      </Helmet>
+      <CreateFlashcardSetDialogue visible={createCardDialogueVisible} setVisible={setCreateCardDialogueVisible} view={view} setReload={setReload}/>
+      <MoveFolderDialogue visible={moveFolderDialogueVisible} setVisible={setMoveFolderDialogueVisible} view={view} setReload={setReload}/>
+      <GridContainer layout={
+        view != "mobile" ? "240px auto"
+        : "auto"
+      } classType="two-column-grid">
+        {view != "mobile" ? <SidePanel selectedItem="flashcards"/> : <></>}
+
+        <GridItem style={{
+          paddingLeft: flashcardBoxHorizontalPadding,
+          paddingRight: flashcardBoxHorizontalPadding,
+          paddingTop: "0px",
+          width: view == "mobile" ? "100vw" : "",
+          display: view == "mobile" ? "block" : "flex",
+          flexDirection: "row",
+          justifyContent: "center",
+        }}>
+        {view == "mobile" ? <HamburgerBar menuVisible={mobileSidePanelVisible} setMenuVisible={setMobileSidePanelVisible} selectedItem="flashcards"/> : <></>}
+  
+          <WhiteOverlay
+            style={{
+                height: "max-content",
+                paddingBottom: view == "mobile" ? "80px" : "",
+                width: view == "desktop" ? "100%" : "calc(100% - 16px)"
+              }}
+            >
+            <div style={{maxWidth: "1200px", margin: "auto"}}>
+              <p>Create a Flashcard</p>
+            </div>
+          </WhiteOverlay>
+
+        </GridItem>
+      </GridContainer>
+    <BlobBackground />
+    </div>
+  );
+}
+
+export default Flashcards;

--- a/frontend/src/screens/Flashcards.js
+++ b/frontend/src/screens/Flashcards.js
@@ -15,6 +15,7 @@ import SearchBar from '../componments/SearchBar/SearchBar';
 import ReviewBarChartKey from '../containers/ReviewBarChartKey/ReviewBarChartKey';
 import MoveFolderDialogue from '../containers/Modal/MoveFolderDialogue/MoveFolderDialogue';
 import CreateFlashcardSetDialogue from '../containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue';
+import CreateFolderDialogue from '../containers/Modal/CreateFolderDialogue';
 import apiManager from '../api/Api';
 import '../componments/Text/Text/Text.css';
 import '../componments/Text/Link/Link.css';
@@ -29,6 +30,7 @@ function Flashcards() {
   const [moveFolderDialogueVisible, setMoveFolderDialogueVisible] = useState(false);
   const [reload, setReload] = useState(true);
   const [createCardDialogueVisible, setCreateCardDialogueVisible] = useState(false);
+  const [createFolderDialogueVisible, setCreateFolderDialogueVisible] = useState(false);
 
   // Set variables for the size
   const mobileBreakpoint = 650;
@@ -87,8 +89,11 @@ function Flashcards() {
             content="width=device-width, initial-scale=1.0">
         </meta>
       </Helmet>
+
       <CreateFlashcardSetDialogue visible={createCardDialogueVisible} setVisible={setCreateCardDialogueVisible} view={view} setReload={setReload}/>
       <MoveFolderDialogue visible={moveFolderDialogueVisible} setVisible={setMoveFolderDialogueVisible} view={view} setReload={setReload}/>
+      <CreateFolderDialogue visible={createFolderDialogueVisible} setVisible={setCreateFolderDialogueVisible} view={view} setReload={setReload}/>
+
       <GridContainer layout={
         view != "mobile" ? "240px auto"
         : "auto"
@@ -127,7 +132,13 @@ function Flashcards() {
                 childValue={todayCards}
               />
               <div style={{float: "left"}}>
-                <GhostButton text="+ New Folder" style={{display: "inline-block", marginRight: "16px"}}/>
+                <GhostButton
+                  text="+ New Folder"
+                  style={{display: "inline-block", marginRight: "16px"}}
+                  onClick={() => {
+                    setCreateFolderDialogueVisible(todayCards);
+                  }}
+                />
                 <Button
                   text="+ New Set"
                   style={{display: "inline-block"}}

--- a/frontend/src/screens/Flashcards.js
+++ b/frontend/src/screens/Flashcards.js
@@ -14,6 +14,7 @@ import GhostButton from '../componments/GhostButton';
 import SearchBar from '../componments/SearchBar/SearchBar';
 import ReviewBarChartKey from '../containers/ReviewBarChartKey/ReviewBarChartKey';
 import MoveFolderDialogue from '../containers/Modal/MoveFolderDialogue/MoveFolderDialogue';
+import CreateFlashcardSetDialogue from '../containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue';
 import apiManager from '../api/Api';
 import '../componments/Text/Text/Text.css';
 import '../componments/Text/Link/Link.css';
@@ -27,6 +28,7 @@ function Flashcards() {
   const [searchTerm, setSearchTerm] = useState(null);
   const [moveFolderDialogueVisible, setMoveFolderDialogueVisible] = useState(false);
   const [reload, setReload] = useState(true);
+  const [createCardDialogueVisible, setCreateCardDialogueVisible] = useState(false);
 
   // Set variables for the size
   const mobileBreakpoint = 650;
@@ -85,6 +87,7 @@ function Flashcards() {
             content="width=device-width, initial-scale=1.0">
         </meta>
       </Helmet>
+      <CreateFlashcardSetDialogue visible={createCardDialogueVisible} setVisible={setCreateCardDialogueVisible} view={view} setReload={setReload}/>
       <MoveFolderDialogue visible={moveFolderDialogueVisible} setVisible={setMoveFolderDialogueVisible} view={view} setReload={setReload}/>
       <GridContainer layout={
         view != "mobile" ? "240px auto"
@@ -125,7 +128,13 @@ function Flashcards() {
               />
               <div style={{float: "left"}}>
                 <GhostButton text="+ New Folder" style={{display: "inline-block", marginRight: "16px"}}/>
-                <Button text="+ New Set" style={{display: "inline-block"}}/>
+                <Button
+                  text="+ New Set"
+                  style={{display: "inline-block"}}
+                  onClick={() => {
+                    setCreateCardDialogueVisible(todayCards);
+                  }}
+                />
               </div>
             </div>
           </WhiteOverlay>


### PR DESCRIPTION
# Added the ability to create flashcard sets

## Description

### 3.1.0 - 2024-06-10

### Added

- New `CreateFlashcardSetDialogue` modal to handle creating a flashcard set
- Added a basic edit-flashcard page  with most features and API calls unimplemented which the `CreateFlashcardSetDialogue` modal takes the user to when a flashcard is created. The page can be passed `newSet`, which if true, won't request flashcard data from the server. When implementing the edit-flashcard page fully, the page should use the API to read flashcard details when `newSet` is not true
- Added basic `CreateFolderDialogue` modal, which does not work yet

### Changed

- Updated `CONTRIBUTING.md` to reflect the latest database changes

## Pull Requestor Checklist

- [x] Does `backend/database/database_config.py` have the type of `production`?
- [x] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [x] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [x] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [x] Has `CHANGELOG.md` been updated to explain the new version?
