### PR TITLE
PATCH: Update margin around text in bento grids LandingPage.js

### DIFF
--- a/frontend/src/screens/LandingPage.js
+++ b/frontend/src/screens/LandingPage.js
@@ -53,7 +53,7 @@ function FeaturesBento({
     <div
       style={{
         textAlign: 'start',
-        margin: view === 'mobile' ? '0 20px' : '0 60px 30px 60px',
+        margin: view === 'mobile' ? '0 20px' : '0 24px 32px 24px',
       }}
     >
       <Subheader text={subheaderText} />


### PR DESCRIPTION
# Title

## Description

The title explains this. I've just decreased the margin (shown in yellow in the image below) from 60px to 24px. 
![image](https://github.com/user-attachments/assets/20be482a-2422-4e57-9626-584b85e85bdc)
