### PR TITLE
PATCH: Flashcard Layout Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ This changelog follows the semantic versioning standard(https://semver.org)
 - N/A
 -->
 
+## 6.1.5 - 2025-02-14
+
+### Added
+
+- Added spacing between the label (`Paragraph`) and input fields using `marginRight`.
+- Introduced `marginBottom` to create spacing between the two input containers.
+- Added Placeholder text in both input containers.
+
+### Fixed
+
+- Ensured both input fields have equal width and alignment.
+- Adjusted label spacing to maintain a consistent layout.
+
+### Changed
+
+- Updated the input container layout for better readability and structure.
+- Changed the new flashcard title from 'Choose a folder' to 'Choose a location'.
 
 ## 6.1.4 - 2025-02-13
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """Package level information
 """
 
-__version__ = "6.1.4"
+__version__ = "6.1.5"

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -96,7 +96,7 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
               variants={dropIn}
               style={view !== "mobile" ? {height: "fit-content"} : null}
             >
-                <Heading3 text="Choose a folder:" />
+                <Heading3 text="Choose a location:" />
 
                 <div className="card-overview" style={{cursor: "pointer"}}>
                   <FolderTreeView visible={visible} selectedPath={selectedPath} setSelectedPath={setSelectedPath}/>
@@ -104,14 +104,14 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
 
                 <Heading3 text="Choose other details:" />
 
-                <div className="input-container">
-                    <Paragraph text="Name: " style={{ display: "flex", alignItems: "center" }} />
-                    <input type="text" className="input" value={flashcardName} onChange={onFlashcardNameChange}/>
+                <div className="input-container" style={{ display: "flex", marginBottom: "4%" }}>
+                    <Paragraph text="Name: " style={{ marginRight: "20%" }} />
+                    <input type="text" className="input" placeholder='Folder name...' value={flashcardName} onChange={onFlashcardNameChange}/>
                 </div>
 
-                <div className="input-container">
-                    <Paragraph text="Description: " style={{ display: "flex", alignItems: "center" }} />
-                    <input type="text" className="input" value={flashcardDescription} onChange={onFlashcardDescriptionChange}/>
+                <div className="input-container" style={{ display: "flex" }}>
+                    <Paragraph text="Description: " style={{ marginRight: "10%" }} />
+                    <input type="text" className="input" placeholder='Folder description' value={flashcardDescription} onChange={onFlashcardDescriptionChange}/>
                 </div>
 
                 <ErrorText text={errorMessage} style={{ display: errorMessageVisibility}} />


### PR DESCRIPTION
# Choose a folder dialogue: rename 'folder' to 'location'

### Added

- Added spacing between the label (`Paragraph`) and input fields using `marginRight`.
- Introduced `marginBottom` to create spacing between the two input containers.
- Added Placeholder text in both input containers.

### Fixed

- Ensured both input fields have equal width and alignment.
- Adjusted label spacing to maintain a consistent layout.

### Changed

- Updated the input container layout for better readability and structure.
- Changed the new flashcard title from 'Choose a folder' to 'Choose a location'.

Fixes #181 

## Pull Requestor Checklist

- [x] Does `backend/database/database_config.py` have the type of `production`?
- [x] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [x] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [x] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [x] Has `CHANGELOG.md` been updated to explain the new version?
