### PR TITLE
PATCH: Fix padding above boxes on dashboard page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ This changelog follows the semantic versioning standard(https://semver.org)
 - N/A
 -->
 
+## 6.4.1 - 2025-02-28
+
+### Fixed
+
+- Fix padding above boxes on dashboard page
+
 ## 6.4.0 - 2025-02-26
 
 ### Added

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """Package level information
 """
 
-__version__ = "6.4.0"
+__version__ = "6.4.1"

--- a/frontend/src/containers/StreakWidget/StreakWidget.js
+++ b/frontend/src/containers/StreakWidget/StreakWidget.js
@@ -22,7 +22,8 @@ function StreakWidget () {
       const overlayStyle = {
         marginLeft: "16px",
         marginRight: "0px",
-        width: "90%"
+        width: "90%",
+        marginTop: "0px"
       }
 
       useEffect(() => {

--- a/frontend/src/screens/Dashboard.js
+++ b/frontend/src/screens/Dashboard.js
@@ -63,7 +63,7 @@ function Dashboard() {
   // Define the third collum, which is rendered at the bottom of the screen if not
   // in desktop mode
   const third_collum = <>
-      <WhiteOverlay style={{width: "100%", marginTop: view === "desktop" ? "72px": "16px"}}>
+      <WhiteOverlay style={{width: "100%", marginTop: view === "desktop" ? "56px": "16px"}}>
         <Heatmap />
       </WhiteOverlay>
 


### PR DESCRIPTION
# Title
Fix padding above boxes on dashboard page

## Description
I have updated the margin for desktop version.
![image](https://github.com/user-attachments/assets/2d6307bc-6d2c-443b-8b5e-c37b92a0577a)

Closes: #174 

## Pull Requestor Checklist

- [x] Does `backend/database/database_config.py` have the type of `production`?
- [x] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [x] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [x] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [x] Has `CHANGELOG.md` been updated to explain the new version?
