### PR TITLE
MINOR: Search within flashcard set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,17 @@ This changelog follows the semantic versioning standard(https://semver.org)
 
 - N/A
 -->
+## 6.6.0 - 2025-03-2
+
+### Added
+
+- Search within flashcard set
+
 ## 6.5.0 - 2025-03-01
 
 ### Added
 
 -Fullscreen Mode for flashcards
-
 
 ## 6.4.2 - 2025-03-1
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """Package level information
 """
 
-__version__ = "6.5.0"
+__version__ = "6.6.0"

--- a/frontend/src/componments/SearchBar/SearchBar.js
+++ b/frontend/src/componments/SearchBar/SearchBar.js
@@ -4,6 +4,7 @@ import '../../containers/Modal/NewGoalPopup/NewGoalPopup.css';
 function SearchBar({
     searchTerm,
     setSearchTerm,
+    onKeyDown=()=>{},
     view,
     marginRight,
     marginTop,
@@ -18,6 +19,7 @@ function SearchBar({
             className={view == "mobile" ? "input-mobile" : "input"}
             value={searchTerm}
             onChange={e => setSearchTerm(e.target.value)}
+            onKeyDown={onKeyDown}
             defaultValue="Search"
             style={{
                 marginBottom: "0px",

--- a/frontend/src/containers/FlashcardSearch/FlashcardSearch.js
+++ b/frontend/src/containers/FlashcardSearch/FlashcardSearch.js
@@ -1,23 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import SearchBar from '../../componments/SearchBar/SearchBar';
 import Button from '../../componments/Button/Button';
 
-const FlashcardSearch = ({ view }) => {
+const FlashcardSearch = ({ view, currentValue="", handleSearchClick}) => {
+  const [updateSearchValue, setUpdateSearchValue] = useState("")
+
+  useEffect(() => {
+    setUpdateSearchValue(currentValue)
+  }, [currentValue])
+
   return (
     <div className="search-bar">
       <SearchBar
-        searchTerm={""}
-        setSearchTerm={console.log}
+        searchTerm={updateSearchValue}
+        setSearchTerm={setUpdateSearchValue}
+        onKeyDown={event => event.key === 'Enter' && handleSearchClick(updateSearchValue)}
         view={view}
+        marginTop="8px"
         marginRight="0px"
         borderRadius="8px 0 0 8px"
         paddingBottom="8px"
         placeholder="Search..."
-        width="100%"
+        width={view === "mobile"? "calc(100% - 26px)" : "calc(100% - 42px)"}
       />
       <Button
         text="Search"
-        onClick={() => { alert("Searching") }}
+        onClick={() => handleSearchClick(updateSearchValue)}
         style={{
           marginTop: "8px",
           marginBottom: "8px",

--- a/frontend/src/containers/Modal/NewFlashcardPopup/NewFlashcardPopup.js
+++ b/frontend/src/containers/Modal/NewFlashcardPopup/NewFlashcardPopup.js
@@ -22,7 +22,8 @@ function NewFlashcardPopup({
     initialTerm="",
     initialDefinition="",
     flashcardName,
-    flashcardDescription
+    flashcardDescription,
+    unsetSearchValue
     }) {
     const [term, setTerm] = useState(initialTerm);
     const [definition, setDefinition] = useState(initialDefinition);
@@ -47,6 +48,7 @@ function NewFlashcardPopup({
         // If the flashcard is being added, append the new data
         if (!editExistingFlashcard) {
             newFlashcardItems.push({front: term, back: definition});
+            unsetSearchValue("")
         } else {
             // If the flashcard is being edited, replace the data
             for (var i = 0; i < newFlashcardItems.length; i++) {

--- a/frontend/src/screens/EditFlashcard.js
+++ b/frontend/src/screens/EditFlashcard.js
@@ -29,6 +29,7 @@ function Flashcards() {
   const mobileBreakpoint = 650;
   const tabletBreakpoint = 1090;
   const [mobileSidePanelVisible, setMobileSidePanelVisible] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
   const [sortType, setSortType] = useState("most-recent");
   const [NewFlashcardPopupVisible, setNewFlashcardPopupVisible] = useState(false);
   const [editFlashcardPopupVisible, setEditFlashcardPopupVisible] = useState(false);
@@ -74,6 +75,9 @@ function Flashcards() {
     }
   }, [flashcardData]);
 
+  const flashcardItemsFiltered = searchValue 
+    ? flashcardItems.filter(card => [card.front, card.back].some(text => text.toLowerCase().includes(searchValue.toLowerCase()))) 
+    : flashcardItems
 
   return (
     <div style={{ top: "0px" }}>
@@ -92,6 +96,7 @@ function Flashcards() {
         folder={folder}
         flashcardName={flashcardName}
         flashcardDescription={description}
+        unsetSearchValue={setSearchValue}
       />
       <NewFlashcardPopup
         visible={editFlashcardPopupVisible}
@@ -132,7 +137,7 @@ function Flashcards() {
           >
             <div style={{ maxWidth: "1200px", margin: "auto" }}>
               <FlashcardHeader newSet={newSet} flashcardName={flashcardName} folder={folder} flashcardID={flashcardID}/>
-              <FlashcardSearch view={view} />
+              <FlashcardSearch view={view} currentValue={searchValue} handleSearchClick={setSearchValue}/>
               <FlashcardSort sortType={sortType} handleOptionChange={handleOptionChange} />
 
               <Button text="+ New Card" onClick={() => setNewFlashcardPopupVisible(true)} />
@@ -147,8 +152,8 @@ function Flashcards() {
                 ? <div className={"loading-icon-wrapper"}>
                   <DelayedElement child={<></>} childValue={null} />
                 </div>
-                : flashcardData.cards?.length !== 0
-                  ? flashcardItems.map((item) => (
+                : flashcardData.cards?.length !== 0 && flashcardItemsFiltered?.length !== 0
+                  ? flashcardItemsFiltered.map((item) => (
                     <FlashcardRow
                       key={item.id}
                       cardID={item.cardID}


### PR DESCRIPTION
# Add Ability to Search Within Flashcard Set

## Description

This PR implements a search logic for flashcards within a set, handling different behaviors when editing, creating, or deleting cards.

- When editing a card, the search context remains active.
- After creating a card, the search bar is cleared, and all cards in the collection are displayed.
- Deleting a card also clears the search bar and shows all remaining cards.

In Addition was fixed the UI for input relating to the search button, add calc() to remove the margin and padding from 100% of the width related to  mobile view.

resolve #226 

## Pull Requestor Checklist

- [x] Does `backend/database/database_config.py` have the type of `production`?
- [x] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [x] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [x] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [x] Has `CHANGELOG.md` been updated to explain the new version?
