### PR TITLE
PATCH: Choose a folder dialogue: add placeholder text and increase height of description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ This changelog follows the semantic versioning standard(https://semver.org)
 - N/A
 -->
 
+## 6.4.2 - 2025-03-1
+
+### Fixed
+
+- Choose a folder dialogue: add placeholder text and increase height of description
+
 ## 6.4.0 - 2025-02-26
 
 ### Added

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """Package level information
 """
 
-__version__ = "6.4.0"
+__version__ = "6.4.2"

--- a/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
+++ b/frontend/src/containers/Modal/CreateFlashcardSetDialogue/CreateFlashcardSetDialogue.js
@@ -111,7 +111,7 @@ function CreateFlashcardSetDialogue({ visible, setVisible, view, setReload }) {
 
                 <div className="input-container" style={{ display: "flex" }}>
                     <Paragraph text="Description: " style={{ marginRight: "10%" }} />
-                    <input type="text" className="input" placeholder='Folder description' value={flashcardDescription} onChange={onFlashcardDescriptionChange}/>
+                    <textarea cols="40" rows="5" style={{ resize: "none" }} className="input" placeholder='Folder description' value={flashcardDescription} onChange={onFlashcardDescriptionChange}/>
                 </div>
 
                 <ErrorText text={errorMessage} style={{ display: errorMessageVisibility}} />


### PR DESCRIPTION
# Title
Choose a folder dialogue: add placeholder text and increase height of description

## Description
![image](https://github.com/user-attachments/assets/77dcffc4-dc4e-40d9-887c-f1c2e6171ab2)

Closes: #180
## Pull Requestor Checklist

- [x] Does `backend/database/database_config.py` have the type of `production`?
- [x] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [x] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [x] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [x] Has `CHANGELOG.md` been updated to explain the new version?
