### PR TITLE
PATCH: Import flashcards bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This changelog follows the semantic versioning standard(https://semver.org)
 
 ### Fixed
 
-- Fixed bug when importing flashcards. JWT token is required to import flashcard, and this is checked using validate_form
+- Fixed bug for `import-flashcards`. JWT token is required to import flashcard, and this is checked using validate_form
 
 ## 6.13.1 - 2025-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ This changelog follows the semantic versioning standard(https://semver.org)
 - N/A
 -->
 
+## 6.13.2 - 2025-05-01
+
+### Fixed
+
+- Fixed bug when importing flashcards. JWT token is required to import flashcard, and this is checked using validate_form
+
 ## 6.13.1 - 2025-04-21
 
 ### Added

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """Package level information
 """
 
-__version__ = "6.13.1"
+__version__ = "6.13.2"

--- a/backend/database/database_config.py
+++ b/backend/database/database_config.py
@@ -1,2 +1,2 @@
-type="production"
-# type="local"
+# type="production"
+type="local"

--- a/backend/database/database_config.py
+++ b/backend/database/database_config.py
@@ -1,2 +1,2 @@
-# type="production"
-type="local"
+type="production"
+# type="local"

--- a/backend/routes/api/card_management.py
+++ b/backend/routes/api/card_management.py
@@ -79,6 +79,16 @@ ADD_PUBLIC_FLASHCARD_TO_FOLDER = {"jwtToken": "", "flashcardID": "", "folder": "
 
 FLASHCARD_EXISTS_FORMAT = {"jwtToken": "", "flashcardID": ""}
 
+IMPORT_FROM_CSV_FORMAT = {
+    "file": "",
+    "jwtToken": "",
+    "flashcardName": "",
+    "flashcardDescription": "",
+    "folder": "",
+    "delimiter": "",
+    "firstRowOfData": ""
+}
+
 IMPORT_FROM_QUIZLET_FORMAT = {
     "jwtToken": "",
     "folder": "",
@@ -818,7 +828,8 @@ def import_from_quizlet():
 
 
 @card_management_routes.route("/api/import-flashcards", methods=["POST"])
-def import_flashcards():
+@validate_form(IMPORT_FROM_CSV_FORMAT)
+def import_flashcards(user_id):
     """Import flashcards from a CSV file.
 
     Expected request format:
@@ -837,7 +848,6 @@ def import_flashcards():
 
         file = request.files["file"]
 
-        user_id = request.form.get("userID")
         folder = request.form.get("folder")
         delimiter = request.form.get("delimiter")
         flashcard_name = request.form.get("flashcardName")


### PR DESCRIPTION
# Title

## Description

### 6.13.2 - 2025-05-01

#### Fixed

- Fixed bug for `import-flashcards`. JWT token is required to import flashcard, and this is checked using validate_form

## Pull Requestor Checklist

- [ ] Does `backend/database/database_config.py` have the type of `production`?
- [ ] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [ ] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [ ] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [ ] Has `CHANGELOG.md` been updated to explain the new version?
