### PR TITLE
Remove toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ This changelog follows the semantic versioning standard(https://semver.org)
 - N/A
 -->
 
+## 6.15.0 - 2025-06-13
+
+### Changed
+
+- Removed ToggleButton component from Sidebar for cleaner UI.
+
 ## 6.14.1 - 2025-06-02
 
 ## Fixed

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,5 +1,5 @@
 """Package level information
 """
 
-__version__ = "6.14.1"
+__version__ = "6.15.0"
 

--- a/frontend/src/containers/SidePanel/SidePanel.js
+++ b/frontend/src/containers/SidePanel/SidePanel.js
@@ -55,11 +55,6 @@ function SidePanel ({ selectedItem }) {
                 clicked={selectedItem == "settings" ? true : false}
                 imgUrl={selectedItem == "settings" ? settings_icon_clicked : settings_icon}
             />
-            <MenuItem 
-                text="Toggle Theme" 
-                onClick={toggleTheme}
-                imgUrl={selectedItem == "settings" ? settings_icon : settings_icon}
-            />
         </div>
     </div>;
 }


### PR DESCRIPTION
# Title
Remove ToggleButton from Sidebar

## Description
issue: #278 
This PR removes the ToggleButton component from the Sidebar for a cleaner and simplified UI.
This is a minor change and backward-compatible.

image of change below

![Screenshot from 2025-06-13 12-45-09](https://github.com/user-attachments/assets/49cdeb7b-8cec-4b36-a775-78cc88fc5670)


Has an accurate description of the details made been given?

Yes

## Pull Requestor Checklist

- [Yes ] Does `backend/database/database_config.py` have the type of `production`?
- [ Yes] Does `frontend/src/api/config.js` have the correct server url, reading from the deployed instance at `http://dolphinflashcards.com/api/`?
- [Yes ] If not merging `development` to `main`, is the MR title prefixed with `MAJOR`, `MINOR` or `PATCH`?
- [ Yes] Has `backend/__init__.py` been updated with the relevant version, following the [semantic versioning standard](https://semver.org)
- [ Yes] Has `CHANGELOG.md` been updated to explain the new version?
